### PR TITLE
fix: drop broken CI badges from public pol-staker README

### DIFF
--- a/contracts/pol-staker/README.md
+++ b/contracts/pol-staker/README.md
@@ -1,9 +1,4 @@
-# POL Staker 🥩 [![Github Actions][gha-badge]][gha] [![Coverage][codecov-badge]][codecov]
-
-[gha]: https://github.com/TruFin-io/smart-contracts/actions
-[gha-badge]: https://github.com/TruFin-io/smart-contracts/actions/workflows/on-pol-staker-changes.yml/badge.svg
-[codecov]: https://codecov.io/gh/TruFin-io/smart-contracts
-[codecov-badge]: https://codecov.io/gh/TruFin-io/smart-contracts/branch/main/graph/badge.svg?token=BIRPGL2TUA
+# POL Staker 🥩
 
 ### Setup
 


### PR DESCRIPTION
## What
Removes the GitHub Actions and Codecov badges (and their reference definitions) from the pol-staker README.

## Why
Both badges pointed at the **private** `smart-contracts` repo, so they render broken for external viewers of this public mirror. The Codecov one also exposed a graph token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removed the GitHub Actions and Codecov badges from the pol-staker README, along with their reference definitions. This avoids broken links to the private smart-contracts repository and removes the exposed Codecov graph token from the public mirror.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->