### PR TITLE
Updating documentation

### DIFF
--- a/contracts/matic-staker/contracts/main/TruStakeMATICv2.sol
+++ b/contracts/matic-staker/contracts/main/TruStakeMATICv2.sol
@@ -352,6 +352,10 @@ contract TruStakeMATICv2 is
     /// @notice Allocates the validation rewards earned by an amount of the caller's staked MATIC to a user.
     /// @param _amount The amount of staked MATIC to allocate.
     /// @param _recipient The address of the target recipient.
+    /// @dev Allocations are an accounting tool, not an on-chain obligation: they do not lock funds or
+    /// entitle the recipient to a payout. Over-allocation is intentional — the bound here is a
+    /// zero-balance / maxWithdraw sanity check and deliberately does not subtract existing allocations,
+    /// and distributors are not required to keep enough funds to cover all allocations at once.
     function allocate(uint256 _amount, address _recipient) external onlyWhitelist nonReentrant whenNotPaused {
         _checkNotZeroAddress(_recipient);
 
@@ -419,6 +423,9 @@ contract TruStakeMATICv2 is
     /// @notice Deallocates an amount of MATIC previously allocated to a user.
     /// @param _amount The amount the caller wishes to reduce the target's allocation by.
     /// @param _recipient The address of the user whose allocation is being reduced.
+    /// @dev Deallocating without first distributing intentionally discards the recipient's
+    /// previously-accrued allocation rewards. This is by design: allocations are not an obligation, so
+    /// recipients are never entitled to a payout.
     function deallocate(uint256 _amount, address _recipient) external onlyWhitelist nonReentrant whenNotPaused {
         Allocation storage individualAllocation = allocations[msg.sender][_recipient][false];
 
@@ -575,6 +582,8 @@ contract TruStakeMATICv2 is
     /// @param _inMatic A value indicating whether the reward is in MATIC or not.
     /// @dev If _inMatic is set to true, the MATIC will be transferred straight from the distributor's wallet.
     /// Their TruMATIC balance will not be altered.
+    /// @dev Rounding truncates in favour of the allocator by design; since allocations are not binding,
+    /// this causes no entitlement loss and can be avoided by waiting longer before distributing.
     function distributeRewards(address _recipient, bool _inMatic) public onlyWhitelist nonReentrant whenNotPaused {
         (uint256 globalPriceNum, uint256 globalPriceDenom) = sharePrice();
         _distributeRewards(_recipient, msg.sender, _inMatic, globalPriceNum, globalPriceDenom);

--- a/contracts/pol-staker/contracts/interfaces/ITruStakePOL.sol
+++ b/contracts/pol-staker/contracts/interfaces/ITruStakePOL.sol
@@ -333,6 +333,10 @@ interface ITruStakePOL {
         );
 
     /// @notice Gets the maximum amount of POL a user can withdraw from the vault.
+    /// @dev Reflects the full share value including unclaimed rewards. A single withdrawal can only
+    /// unbond up to the amount currently staked on the validator; the remainder becomes withdrawable
+    /// once rewards are restaked via `compoundRewards` (which anyone may call). Attempting to withdraw
+    /// the full amount before that reverts with `WithdrawalAmountAboveValidatorStake` by design.
     /// @param _user The user under consideration.
     /// @return The amount of POL.
     function maxWithdraw(address _user) external view returns (uint256);


### PR DESCRIPTION
Adds clarifying doc comments and README notes on intentional design decisions. Documentation only — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates documentation only. It adds clarifying comments around staking allocation and withdrawal behaviour, making explicit that certain allocation values are accounting-only, that some rewards are intentionally forfeited when deallocating early, and that rounding works in the allocator’s favour by design. It also clarifies how `maxWithdraw` relates to unclaimed rewards, validator stake limits, and the expected revert when trying to withdraw more than the currently restaked amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->